### PR TITLE
Fix GitHub Stars badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![JavaScript](https://img.shields.io/badge/Language-JavaScript-yellow.svg)
 ![Docker](https://img.shields.io/badge/Container-Docker-blue.svg)
 ![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)
-![GitHub Stars](https://img.shields.io/github/stars/davevancauwenberghe/Citymart-Services)
+![GitHub Stars](https://img.shields.io/github/stars/davevancauwenberghe/CityMart-Services)
 
 A lightweight Discord gateway bot for the CityMart Group server. It listens for "@CityMart Services <keyword>" and replies with rich embeds for commands like "community", "experience", "support", and "lorebook".
 


### PR DESCRIPTION
## Summary
- fix typo in GitHub Stars badge URL

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6896b9c3ba74832094c7c211f2fb8593