### PR TITLE
Use lockfile in Docker build and add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.git
+.github
+.vscode
+.DS_Store
+.env
+node_modules
+npm-debug.log*
+Dockerfile
+.dockerignore
+tests
+README.md
+CONTRIBUTING.md
+CODE_OF_CONDUCT.md
+SECURITY.md
+LICENSE

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 # Dockerfile
 FROM node:18-alpine
 WORKDIR /app
-COPY package.json ./
-RUN npm install --only=production
+
+COPY package*.json ./
+RUN npm ci --omit=dev
+
 COPY . .
 CMD ["node", "index.js"]


### PR DESCRIPTION
### Motivation
- The remote Fly build was timing out while resolving dependencies and uploading the full repo context, causing `deadline_exceeded` during the Docker build. 
- The previous Dockerfile only copied `package.json` and ran `npm install`, which ignored the committed lockfile and made dependency resolution non-deterministic and slower. 
- A missing `.dockerignore` caused unnecessary files such as `node_modules`, git metadata, docs, and tests to be sent with the build context increasing build time and surface for errors.

### Description
- Update `Dockerfile` to copy `package*.json` and run `npm ci --omit=dev` so builds use the committed `package-lock.json` for deterministic installs. 
- Add a `.dockerignore` that excludes `.git`, `.github`, `.vscode`, `.env`, `node_modules`, docs, tests, and other local files to reduce the Fly build context size.

### Testing
- Ran `npm test`, which passed. 
- Attempted a local `docker build --no-cache -t citymart-test .` but Docker is not installed in this environment so the image build could not be executed here. 
- Attempted `npm ci` in this environment and observed a `403 Forbidden` from the npm registry for `ws`, which appears to be an environment registry policy issue and does not affect the Dockerfile change itself.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d2693e59c832080465090a634c8d9)